### PR TITLE
[TS導入サンプル] 3. 型アサーションを使ってみよう 

### DIFF
--- a/src/js/modules/weather.ts
+++ b/src/js/modules/weather.ts
@@ -206,7 +206,7 @@ export const weather = async () => {
      * 天気の結果を表示させる関数
      */
     const updateResultBlock = (
-      weatherData: WeatherJson & MainJson,
+      weatherData: ReturnType<typeof formatWeatherData>,
       dataValue: string,
     ) => {
       const weatherResultElement = document.querySelector(
@@ -216,7 +216,9 @@ export const weather = async () => {
       const dataResultKey = "data-weather-result";
       const resultElements = document.querySelectorAll(`[${dataResultKey}]`);
       resultElements.forEach((resultElement) => {
-        const resultId = resultElement.getAttribute(dataResultKey);
+        const resultId = resultElement.getAttribute(
+          dataResultKey,
+        ) as keyof ReturnType<typeof formatWeatherData>;
         if (
           !(resultId === "areaDescription") &&
           !(resultId === "iconURL") &&


### PR DESCRIPTION
`updateResultBlock()`内の`getAttributes()`の戻り値に型が付いておらず、エラーが出ています。
コンパイラーに`getAttributes()`の戻り値の型を教えてあげるために、[型アサーション](https://typescriptbook.jp/reference/values-types-variables/type-assertion-as)を使ってみましょう！

> [!NOTE]
> 差分はあくまで例です。詰まった際やお時間がない時の参考にしてもらえれば！

## やること

- `getAttributes()`の戻り値の型を上書きする
- (可能であれば) [ユーティリティ型](https://typescriptbook.jp/reference/type-reuse/utility-types)を使って、アサーションをスッキリ書いてみる

※一旦`weather`モジュールのみを対象としています

## 参考

